### PR TITLE
Add AddUsersToTeam.ps1 Script to Main

### DIFF
--- a/AddUsersToTeam.ps1
+++ b/AddUsersToTeam.ps1
@@ -1,0 +1,1 @@
+Import-CSV .\FileName.csv | ForEach-Object {Add-TeamUser -GroupId [GroupId] -User $($_.Email))


### PR DESCRIPTION
AddUsersToTeam.ps1 utilizes a for loop that uses user emails to add users to a newly created Team on Microsoft Teams.